### PR TITLE
Add clipboard history navigation and screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/droidnova/codex_testing/ClipboardViewModel.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ClipboardViewModel.kt
@@ -1,0 +1,31 @@
+package com.droidnova.codex_testing
+
+import android.app.Application
+import android.content.ClipboardManager
+import androidx.compose.runtime.mutableStateListOf
+import androidx.core.content.getSystemService
+import androidx.lifecycle.AndroidViewModel
+
+class ClipboardViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val clipboardManager: ClipboardManager? = application.getSystemService()
+
+    val clipboardHistory = mutableStateListOf<String>()
+
+    private val listener = ClipboardManager.OnPrimaryClipChangedListener {
+        val clip = clipboardManager?.primaryClip
+        val text = clip?.getItemAt(0)?.coerceToText(application).toString()
+        if (text.isNotBlank()) {
+            clipboardHistory.add(0, text)
+        }
+    }
+
+    init {
+        clipboardManager?.addPrimaryClipChangedListener(listener)
+    }
+
+    override fun onCleared() {
+        clipboardManager?.removePrimaryClipChangedListener(listener)
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
@@ -4,13 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.droidnova.codex_testing.navigation.AppNavHost
 import com.droidnova.codex_testing.ui.theme.Codex_TestingTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +14,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             Codex_TestingTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                val vm: ClipboardViewModel = viewModel()
+                AppNavHost(viewModel = vm)
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    Codex_TestingTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/droidnova/codex_testing/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/navigation/AppNavHost.kt
@@ -1,0 +1,34 @@
+package com.droidnova.codex_testing.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.droidnova.codex_testing.ClipboardViewModel
+import com.droidnova.codex_testing.ui.AboutScreen
+import com.droidnova.codex_testing.ui.HomeScreen
+
+@Composable
+fun AppNavHost(
+    viewModel: ClipboardViewModel,
+    navController: NavHostController = rememberNavController(),
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = "home",
+        modifier = modifier
+    ) {
+        composable("home") {
+            HomeScreen(
+                viewModel = viewModel,
+                onNavigateToAbout = { navController.navigate("about") }
+            )
+        }
+        composable("about") {
+            AboutScreen(onBack = { navController.popBackStack() })
+        }
+    }
+}

--- a/app/src/main/java/com/droidnova/codex_testing/ui/AboutScreen.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ui/AboutScreen.kt
@@ -1,0 +1,37 @@
+package com.droidnova.codex_testing.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("About") },
+                navigationIcon = {
+                    TextButton(onClick = onBack) {
+                        Text("Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(16.dp)
+        ) {
+            Text("This app stores everything you copy to the clipboard.")
+        }
+    }
+}

--- a/app/src/main/java/com/droidnova/codex_testing/ui/HomeScreen.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ui/HomeScreen.kt
@@ -1,0 +1,53 @@
+package com.droidnova.codex_testing.ui
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.droidnova.codex_testing.ClipboardViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen(
+    viewModel: ClipboardViewModel,
+    onNavigateToAbout: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Clipboard History") },
+                actions = {
+                    TextButton(onClick = onNavigateToAbout) {
+                        Text("About")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            items(viewModel.clipboardHistory) { item ->
+                Text(
+                    text = item,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                )
+                Divider()
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+navigationCompose = "2.7.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- track clipboard changes in a ViewModel
- add Compose navigation with home and about screens
- hook navigation into MainActivity

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b2e8f5d7208327b9fcb66a0e49bb0b