### PR TITLE
Persist clipboard history with Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -51,6 +52,9 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/droidnova/codex_testing/ClipboardViewModel.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ClipboardViewModel.kt
@@ -2,21 +2,28 @@ package com.droidnova.codex_testing
 
 import android.app.Application
 import android.content.ClipboardManager
-import androidx.compose.runtime.mutableStateListOf
 import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.droidnova.codex_testing.data.ClipboardDatabase
+import com.droidnova.codex_testing.data.ClipboardItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 class ClipboardViewModel(application: Application) : AndroidViewModel(application) {
 
     private val clipboardManager: ClipboardManager? = application.getSystemService()
+    private val clipboardDao = ClipboardDatabase.getInstance(application).clipboardDao()
 
-    val clipboardHistory = mutableStateListOf<String>()
+    val clipboardHistory: Flow<List<ClipboardItem>> = clipboardDao.getAll()
 
     private val listener = ClipboardManager.OnPrimaryClipChangedListener {
         val clip = clipboardManager?.primaryClip
         val text = clip?.getItemAt(0)?.coerceToText(application).toString()
         if (text.isNotBlank()) {
-            clipboardHistory.add(0, text)
+            viewModelScope.launch {
+                clipboardDao.insert(ClipboardItem(text = text))
+            }
         }
     }
 

--- a/app/src/main/java/com/droidnova/codex_testing/data/ClipboardDao.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/data/ClipboardDao.kt
@@ -1,0 +1,16 @@
+package com.droidnova.codex_testing.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ClipboardDao {
+    @Query("SELECT * FROM clipboard ORDER BY timestamp DESC")
+    fun getAll(): Flow<List<ClipboardItem>>
+
+    @Insert
+    suspend fun insert(item: ClipboardItem)
+}
+

--- a/app/src/main/java/com/droidnova/codex_testing/data/ClipboardDatabase.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/data/ClipboardDatabase.kt
@@ -1,0 +1,27 @@
+package com.droidnova.codex_testing.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [ClipboardItem::class], version = 1, exportSchema = false)
+abstract class ClipboardDatabase : RoomDatabase() {
+    abstract fun clipboardDao(): ClipboardDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: ClipboardDatabase? = null
+
+        fun getInstance(context: Context): ClipboardDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    ClipboardDatabase::class.java,
+                    "clipboard.db"
+                ).build().also { INSTANCE = it }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/droidnova/codex_testing/data/ClipboardItem.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/data/ClipboardItem.kt
@@ -1,0 +1,12 @@
+package com.droidnova.codex_testing.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "clipboard")
+data class ClipboardItem(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val text: String,
+    val timestamp: Long = System.currentTimeMillis()
+)
+

--- a/app/src/main/java/com/droidnova/codex_testing/ui/HomeScreen.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ui/HomeScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.droidnova.codex_testing.ClipboardViewModel
@@ -34,14 +36,16 @@ fun HomeScreen(
             )
         }
     ) { innerPadding ->
+        val history by viewModel.clipboardHistory.collectAsState(initial = emptyList())
+
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            items(viewModel.clipboardHistory) { item ->
+            items(history) { item ->
                 Text(
-                    text = item,
+                    text = item.text,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 navigationCompose = "2.7.7"
+room = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,9 +28,13 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- add Room dependency management and kapt plugin
- persist clipboard items via Room and expose Flow to UI
- update UI to display stored clipboard history

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b2ec3acdc8832784d554043681dc20