### PR TITLE
Add foreground clipboard monitoring service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -22,6 +24,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".ClipboardService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -26,7 +27,8 @@
         </activity>
         <service
             android:name=".ClipboardService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
@@ -7,6 +7,7 @@ import android.content.ClipboardManager
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import com.droidnova.codex_testing.data.ClipboardDatabase
@@ -25,16 +26,19 @@ class ClipboardService : Service() {
         val clip = clipboardManager.primaryClip
         val text = clip?.getItemAt(0)?.coerceToText(this).toString()
         if (text.isNotBlank()) {
+            Log.d(TAG, "Clipboard changed: $text")
             scope.launch {
                 ClipboardDatabase.getInstance(applicationContext)
                     .clipboardDao()
                     .insert(ClipboardItem(text = text))
+                Log.d(TAG, "Stored clipboard text")
             }
         }
     }
 
     override fun onCreate() {
         super.onCreate()
+        Log.d(TAG, "Service created")
         clipboardManager = getSystemService<ClipboardManager>()!!
         clipboardManager.addPrimaryClipChangedListener(listener)
         createNotificationChannel()
@@ -47,6 +51,7 @@ class ClipboardService : Service() {
     }
 
     override fun onDestroy() {
+        Log.d(TAG, "Service destroyed")
         clipboardManager.removePrimaryClipChangedListener(listener)
         scope.cancel()
         super.onDestroy()
@@ -69,6 +74,7 @@ class ClipboardService : Service() {
     companion object {
         private const val CHANNEL_ID = "clipboard_service"
         private const val NOTIFICATION_ID = 1
+        private const val TAG = "ClipboardService"
     }
 }
 

--- a/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
@@ -1,0 +1,74 @@
+package com.droidnova.codex_testing
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.ClipboardManager
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.getSystemService
+import com.droidnova.codex_testing.data.ClipboardDatabase
+import com.droidnova.codex_testing.data.ClipboardItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+class ClipboardService : Service() {
+
+    private val scope = CoroutineScope(Dispatchers.IO + Job())
+    private lateinit var clipboardManager: ClipboardManager
+    private val listener = ClipboardManager.OnPrimaryClipChangedListener {
+        val clip = clipboardManager.primaryClip
+        val text = clip?.getItemAt(0)?.coerceToText(this).toString()
+        if (text.isNotBlank()) {
+            scope.launch {
+                ClipboardDatabase.getInstance(applicationContext)
+                    .clipboardDao()
+                    .insert(ClipboardItem(text = text))
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        clipboardManager = getSystemService<ClipboardManager>()!!
+        clipboardManager.addPrimaryClipChangedListener(listener)
+        createNotificationChannel()
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.clipboard_notification_title))
+            .setContentText(getString(R.string.clipboard_notification_text))
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .build()
+        startForeground(NOTIFICATION_ID, notification)
+    }
+
+    override fun onDestroy() {
+        clipboardManager.removePrimaryClipChangedListener(listener)
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.clipboard_notification_channel),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "clipboard_service"
+        private const val NOTIFICATION_ID = 1
+    }
+}
+

--- a/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.droidnova.codex_testing
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.droidnova.codex_testing.navigation.AppNavHost
 import com.droidnova.codex_testing.ui.theme.Codex_TestingTheme
@@ -11,6 +13,10 @@ import com.droidnova.codex_testing.ui.theme.Codex_TestingTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        ContextCompat.startForegroundService(
+            this,
+            Intent(this, ClipboardService::class.java)
+        )
         enableEdgeToEdge()
         setContent {
             Codex_TestingTheme {

--- a/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
@@ -1,10 +1,14 @@
 package com.droidnova.codex_testing
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.droidnova.codex_testing.navigation.AppNavHost
@@ -13,6 +17,18 @@ import com.droidnova.codex_testing.ui.theme.Codex_TestingTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                0
+            )
+        }
         ContextCompat.startForegroundService(
             this,
             Intent(this, ClipboardService::class.java)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Codex_Testing</string>
+    <string name="clipboard_notification_channel">Clipboard Monitor</string>
+    <string name="clipboard_notification_title">Clipboard monitor active</string>
+    <string name="clipboard_notification_text">Listening for clipboard changes</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement foreground ClipboardService to persist copied text
- start clipboard monitoring service from MainActivity
- declare service and strings for persistent notification

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b2f51ec8648327a12cdbba6e5cdfaf