### PR TITLE
Ensure clipboard service runs with notification permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -26,7 +27,8 @@
         </activity>
         <service
             android:name=".ClipboardService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/ClipboardService.kt
@@ -7,6 +7,7 @@ import android.content.ClipboardManager
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import com.droidnova.codex_testing.data.ClipboardDatabase
@@ -25,16 +26,19 @@ class ClipboardService : Service() {
         val clip = clipboardManager.primaryClip
         val text = clip?.getItemAt(0)?.coerceToText(this).toString()
         if (text.isNotBlank()) {
+            Log.d(TAG, "Clipboard changed: $text")
             scope.launch {
                 ClipboardDatabase.getInstance(applicationContext)
                     .clipboardDao()
                     .insert(ClipboardItem(text = text))
+                Log.d(TAG, "Stored clipboard text")
             }
         }
     }
 
     override fun onCreate() {
         super.onCreate()
+        Log.d(TAG, "Service created")
         clipboardManager = getSystemService<ClipboardManager>()!!
         clipboardManager.addPrimaryClipChangedListener(listener)
         createNotificationChannel()
@@ -47,6 +51,7 @@ class ClipboardService : Service() {
     }
 
     override fun onDestroy() {
+        Log.d(TAG, "Service destroyed")
         clipboardManager.removePrimaryClipChangedListener(listener)
         scope.cancel()
         super.onDestroy()
@@ -69,6 +74,7 @@ class ClipboardService : Service() {
     companion object {
         private const val CHANNEL_ID = "clipboard_service"
         private const val NOTIFICATION_ID = 1
+        private const val TAG = "ClipboardService"
     }
 }
 

--- a/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
+++ b/app/src/main/java/com/droidnova/codex_testing/MainActivity.kt
@@ -1,10 +1,14 @@
 package com.droidnova.codex_testing
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.droidnova.codex_testing.navigation.AppNavHost
@@ -13,6 +17,18 @@ import com.droidnova.codex_testing.ui.theme.Codex_TestingTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                0
+            )
+        }
         ContextCompat.startForegroundService(
             this,
             Intent(this, ClipboardService::class.java)


### PR DESCRIPTION
## Summary
- request POST_NOTIFICATIONS permission and declare foreground service type
- log clipboard service lifecycle and storing events
- ask for notification permission before starting service

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ff4971ec832788b773a65b74f50d